### PR TITLE
License GNU-GPL URL Corrected in switchuser.xml

### DIFF
--- a/switchuser.xml
+++ b/switchuser.xml
@@ -6,7 +6,7 @@
 	<authorEmail>lu@artd.ch</authorEmail>
 	<authorUrl>www.artd.ch</authorUrl>
 	<copyright>Copyright (C) Artd Webdesign GmbH. All rights reserved.</copyright>
-	<license>http://www.gnu.org/licenseses/gpl-2.0.html GNU/GPL</license>
+	<license>http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL</license>
 	<version>3.0.1</version>
 	<description>PLG_SYSTEM_SWITCHUSER_XML_DESCRIPTION</description>
 


### PR DESCRIPTION
First, Thank you for such a wonderful extension! I just noticed the GNU-GPL url was incorrect when I went to see if I could fork and use this code for my own version of a "Switch User' extension. Have a good day!